### PR TITLE
Fix arrow function syntax errors on IE11

### DIFF
--- a/js/ghu-install-vanilla.js
+++ b/js/ghu-install-vanilla.js
@@ -54,14 +54,14 @@
 
 	// Hide element.
 	function displayNone(array) {
-		array.forEach((item) => {
+		array.forEach(function (item) {
 			item.style.display = 'none';
 		});
 	}
 
 	// Display element.
 	function display(array) {
-		array.forEach((item) => {
+		array.forEach(function (item) {
 			item.style.display = '';
 		});
 	}
@@ -75,7 +75,7 @@
 	function vanillaParents(element, selector) {
 		let parents = [];
 		if (NodeList.prototype.isPrototypeOf(element)) {
-			element.forEach((item) => {
+			element.forEach(function (item) {
 				element = item.parentElement.closest(selector);
 				parents.push(element);
 			});


### PR DESCRIPTION
The arrow function syntax is not supported on IE11 browser and cause JS errors.
IE11 should no longer be used but these errors have been logged on some website of Community Supported Agriculture sites where my own plugin is used.
The only subtitle difference between function and arrow function is the inclusion of this context. 